### PR TITLE
Added mutable max buffer size for Encryptor and Decryptor

### DIFF
--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -12,10 +12,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.bouncycastle.bcpg.ArmoredOutputStream;
+
 import org.bouncycastle.openpgp.PGPCompressedData;
 import org.bouncycastle.openpgp.PGPDataValidationException;
-import org.bouncycastle.openpgp.PGPEncryptedData;
 import org.bouncycastle.openpgp.PGPEncryptedDataList;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPLiteralData;
@@ -71,7 +70,7 @@ import org.slf4j.LoggerFactory;
 public class Decryptor {
     protected boolean verificationRequired;
     protected String symmetricPassphrase;
-    protected int maxBufferSize = 0x100000; //1MB
+    protected int maxFileBufferSize = 0x100000; //1MB
     protected Ring ring;
     protected Logger log = LoggerFactory.getLogger(Decryptor.class.getName());
 
@@ -119,17 +118,16 @@ public class Decryptor {
         symmetricPassphrase = x != null ? x : "";
     }
 
-    public int getMaxBufferSize() {
-        return maxBufferSize;
+    public int getMaxFileBufferSize() {
+        return maxFileBufferSize;
     }
 
     /**
      * Decryptor will choose the most appropriate read/write buffer size
-     * for each file. You can set the maximum value here and it must be
-     * power of 2. Defaults to 1MB.
+     * for each file. You can set the maximum value here. Defaults to 1MB.
      */
-    public void setMaxBufferSize(int maxBufferSize) {
-        this.maxBufferSize = maxBufferSize;
+    public void setMaxFileBufferSize(int maxFileBufferSize) {
+        this.maxFileBufferSize = maxFileBufferSize;
     }
 
   /** Keys to use for decryption and verification. */
@@ -178,7 +176,7 @@ public class Decryptor {
         OutputStream output = null;
         try {
             int bestBufferSize =
-                Util.bestBufferSize(plaintext.length(), maxBufferSize);
+                Util.bestFileBufferSize(ciphertext.length(), maxFileBufferSize);
             input = new BufferedInputStream(
                 new FileInputStream(ciphertext), bestBufferSize);
             output = new BufferedOutputStream(

--- a/src/main/java/org/c02e/jpgpj/util/Util.java
+++ b/src/main/java/org/c02e/jpgpj/util/Util.java
@@ -52,4 +52,16 @@ public class Util {
         }
         return new String(chars);
     }
+
+  /**
+   * Returns the fileSize rounded up to exact power of 2 with a maximum
+   * of maxBufferSize (which should be power of 2).
+   */
+    public static int bestBufferSize(long fileSize, int maxBufferSize) {
+        if (fileSize>=maxBufferSize) return maxBufferSize;
+        else {
+            return 1 << (32 - Long.numberOfLeadingZeros(fileSize));
+        }
+    }
+
 }

--- a/src/main/java/org/c02e/jpgpj/util/Util.java
+++ b/src/main/java/org/c02e/jpgpj/util/Util.java
@@ -54,14 +54,12 @@ public class Util {
     }
 
   /**
-   * Returns the fileSize rounded up to exact power of 2 with a maximum
-   * of maxBufferSize (which should be power of 2).
+   * Returns the exact fileSize with a maximum of maxFileBufferSize.
    */
-    public static int bestBufferSize(long fileSize, int maxBufferSize) {
-        if (fileSize>=maxBufferSize) return maxBufferSize;
-        else {
-            return 1 << (32 - Long.numberOfLeadingZeros(fileSize));
-        }
+    public static int bestFileBufferSize(long fileSize, int maxFileBufferSize) {
+        return (fileSize>=maxFileBufferSize) ?
+            maxFileBufferSize :
+            Math.toIntExact(fileSize);
     }
 
 }


### PR DESCRIPTION
These are the changes that we talked about in Issue #14 . I haven't included any change in versions, as I thought you would want to do it when you are happy for releasing a new one.

I'm not sure if the buffer size must be a power of 2, but I've made this assumption.

Any comment or correction is welcome!