### PR TITLE
Handle case where master key can be used for encryption to match gpg

### DIFF
--- a/src/main/java/org/c02e/jpgpj/Subkey.java
+++ b/src/main/java/org/c02e/jpgpj/Subkey.java
@@ -278,6 +278,12 @@ public class Subkey {
             if (hashedSubPackets != null)
                 flags |= hashedSubPackets.getKeyFlags();
         }
+
+        // Handle case where master key is flagged for encryption to match gpg implementation
+        if ( publicKey.isEncryptionKey() ) {
+            flags |= PGPKeyFlags.CAN_ENCRYPT_COMMS;
+        }
+
         return flags;
     }
 


### PR DESCRIPTION
Justin,

Wonderful project!  I've been a gpg user for years and have some specific cases where I am encrypting data using the parent key, not just subkeys. 

Could you advise on a more elegant way to support this use case?  I'm new to your codebase.

Taylor