### PR TITLE
Allow passphrases to be supplied as char arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ throws ServletException, IOException {
     if (message == null || message.length() == 0)
         message = "the medium is the message";
 
+    Encryptor encryptor = null;
     try {
         // use Bob's public key for encryption
-        Encryptor encryptor = new Encryptor(
+        encryptor = new Encryptor(
             new Key(new File("path/to/my/keys/bob-pub.gpg"))
         );
         // use custom encryption, signing, and compression algorithms
@@ -74,7 +75,9 @@ throws ServletException, IOException {
                 subkey.setForEncryption(false);
             // unlock Alice's signing subkey with a passphrase of "password123"
             if (subkey.isForSigning())
-                subkey.setPassphrase("password123");
+                subkey.setPassphraseChars(new char[] {
+                    'p','a','s','s','w','o','r','d','1','2','3'
+                });
         }
         encryptor.getRing().getKeys().add(alice);
 
@@ -86,6 +89,10 @@ throws ServletException, IOException {
         );
     } catch (PGPException e) {
         throw new ServletException(e);
+    } finally {
+        // zero-out passphrase and release private key material for GC
+        if (encryptor != null)
+            encryptor.clearSecrets();
     }
 }
 ```

--- a/src/main/java/org/c02e/jpgpj/Key.java
+++ b/src/main/java/org/c02e/jpgpj/Key.java
@@ -84,6 +84,19 @@ public class Key {
      * and sets the passphrase of all subkeys to the specified passphrase.
      * @throws PGPException if the text contains no keys.
      */
+    public Key(String armor, char[] passphraseChars)
+    throws IOException, PGPException {
+        this(armor);
+        setPassphraseChars(passphraseChars);
+    }
+
+    /**
+     * Loads first key from the specified armored text,
+     * and sets the passphrase of all subkeys to the specified passphrase.
+     * Prefer {@link #Key(String, char[])} to avoid creating
+     * extra copies of the passphrase in memory that cannot be cleaned up.
+     * @throws PGPException if the text contains no keys.
+     */
     public Key(String armor, String passphrase)
     throws IOException, PGPException {
         this(armor);
@@ -104,6 +117,18 @@ public class Key {
      * and sets the passphrase of all subkeys to the specified passphrase.
      * @throws PGPException if the file contains no keys.
      */
+    public Key(File file, char[] passphraseChars) throws IOException, PGPException {
+        this(file);
+        setPassphraseChars(passphraseChars);
+    }
+
+    /**
+     * Loads first key from the specified file,
+     * and sets the passphrase of all subkeys to the specified passphrase.
+     * Prefer {@link #Key(File, char[])} to avoid creating
+     * extra copies of the passphrase in memory that cannot be cleaned up.
+     * @throws PGPException if the file contains no keys.
+     */
     public Key(File file, String passphrase) throws IOException, PGPException {
         this(file);
         setPassphrase(passphrase);
@@ -121,6 +146,19 @@ public class Key {
     /**
      * Loads first key from the specified input stream,
      * and sets the passphrase of all subkeys to the specified passphrase.
+     * @throws PGPException if the input streame contains no keys.
+     */
+    public Key(InputStream stream, char[] passphraseChars)
+    throws IOException, PGPException {
+        this(stream);
+        setPassphraseChars(passphraseChars);
+    }
+
+    /**
+     * Loads first key from the specified input stream,
+     * and sets the passphrase of all subkeys to the specified passphrase.
+     * Prefer {@link #Key(InputStream, char[])} to avoid creating
+     * extra copies of the passphrase in memory that cannot be cleaned up.
      * @throws PGPException if the input streame contains no keys.
      */
     public Key(InputStream stream, String passphrase)
@@ -161,6 +199,18 @@ public class Key {
 
     /**
      * Sets the passphrase of all subkeys.
+     * @see Subkey#setPassphraseChars
+     */
+    public void setPassphraseChars(char[] x) {
+        for (Subkey subkey : subkeys)
+            subkey.setPassphraseChars(x);
+    }
+
+    /**
+     * Sets the passphrase of all subkeys.
+     * Prefer {@link #setPassphraseChars} to avoid creating extra copies
+     * of the passphrase in memory that cannot be cleaned up.
+     * @see Subkey#setPassphraseChars
      */
     public void setPassphrase(String x) {
         for (Subkey subkey : subkeys)
@@ -363,6 +413,18 @@ public class Key {
      */
     public boolean matches(Pattern id) {
         return !findAll(id).isEmpty();
+    }
+
+    /**
+     * Zeroes-out the cached passphrase for all subkeys,
+     * and releases the extracted private key material for garbage collection.
+     * Note that if {@link #setPassphrase} is
+     * used to access the passphrase, the passphrase data cannot be zeroed
+     * (so instead use {@link #setPassphraseChars}).
+     */
+    public void clearSecrets() {
+        for (Subkey subkey : subkeys)
+            subkey.clearSecrets();
     }
 
     /**

--- a/src/main/java/org/c02e/jpgpj/Ring.java
+++ b/src/main/java/org/c02e/jpgpj/Ring.java
@@ -226,6 +226,15 @@ public class Ring {
     }
 
     /**
+     * Zeroes-out the cached passphrase for all keys,
+     * and releases the extracted private key material for garbage collection.
+     */
+    public void clearSecrets() {
+        for (Key key : keys)
+            key.clearSecrets();
+    }
+
+    /**
      * Loads all keys from the specified armored text,
      * and adds them to this ring's existing list of keys.
      */

--- a/src/main/java/org/c02e/jpgpj/util/Util.java
+++ b/src/main/java/org/c02e/jpgpj/util/Util.java
@@ -10,6 +10,13 @@ import java.util.regex.Pattern;
 public class Util {
 
     /**
+     * True if the specified character array is null or empty.
+     */
+    public static boolean isEmpty(char[] a) {
+        return a == null || a.length == 0;
+    }
+
+    /**
      * True if the specified string is null or empty.
      */
     public static boolean isEmpty(String s) {

--- a/src/test/groovy/org/c02e/jpgpj/util/UtilSpec.groovy
+++ b/src/test/groovy/org/c02e/jpgpj/util/UtilSpec.groovy
@@ -6,6 +6,14 @@ class UtilSpec extends Specification {
 
     // isEmpty
 
+    def "char array is empty when blank"() {
+        expect: Util.isEmpty([] as char[])
+    }
+
+    def "char array is not empty when not blank"() {
+        expect: !Util.isEmpty([0] as char[])
+    }
+
     def "string is empty when blank"() {
         expect: Util.isEmpty('')
     }


### PR DESCRIPTION
and to be zeroed after use; for #19

* Updated the `Subkey` class to:
  * Add new `passphraseChars` property, allowing a subkey's passphrase
    to be set and cached as a `char[]` instead of as a `String` object.
  * Add new `unlock()` method, allowing the subkey to be unlocked
    without caching the passphrase at all.
  * Cache the private-key material (in the form of a `PGPPrivateKey`
    object) after the subkey has been unlocked.
  * Add new `clearSecrets()` method, allowing the cached private-key
    material to be released for garbage collection, and zeroing-out the
    cached `char[]` passphrase.

* Updated the `Key` class to:
  * Add new `passphraseChars` setter as a convenience for setting subkey
    `char[]` passphrases.
  * Add new constructors that accept `char[]` passphrases; one each
    corresponding to the old `String` passphrase constructors.
  * Add new `clearSecrets()` method as a convenience for clearing subkey
    secrets.

* Updated the `Ring` class to:
  * Add new `clearSecrets()` method as a convenience for clearing subkey
    secrets.

* Updated the `Encryptor` class to:
  * Add new `symmetricPassphraseChars` property, allowing the passphrase
    for symmetric encryption to be set and cached as a `char[]` instead
    of as a `String` object.
  * Add new `clearSecrets()` method as a convenience for clearing subkey
    secrets, and zeroing-out the cached `char[]` symmetric passphrase.

* Updated the `Decryptor` class to:
  * Add new `symmetricPassphraseChars` property, allowing the passphrase
    for symmetric encryption to be set and cached as a `char[]` instead
    of as a `String` object.
  * Add new `clearSecrets()` method as a convenience for clearing subkey
    secrets, and zeroing-out the cached `char[]` symmetric passphrase.