### PR TITLE
Armour headers support in encryptor and decryptor

### DIFF
--- a/src/main/java/org/c02e/jpgpj/DecryptionResult.java
+++ b/src/main/java/org/c02e/jpgpj/DecryptionResult.java
@@ -10,16 +10,16 @@ import java.util.List;
  */
 public class DecryptionResult {
     private final FileMetadata fileMetadata;
-    private final boolean armoured;
-    private final List<String> armouredHeaders;
+    private final boolean armored;
+    private final List<String> armorHeaders;
 
     public DecryptionResult(
-            FileMetadata fileMetadata, boolean armoured, Collection<String> armouredHeaders) {
+            FileMetadata fileMetadata, boolean armored, Collection<String> armorHeaders) {
         this.fileMetadata = fileMetadata;
-        this.armoured = armoured;
-        this.armouredHeaders = ((armouredHeaders == null) || armouredHeaders.isEmpty())
+        this.armored = armored;
+        this.armorHeaders = ((armorHeaders == null) || armorHeaders.isEmpty())
             ? Collections.emptyList()
-            : Collections.unmodifiableList(new ArrayList<>(armouredHeaders));
+            : Collections.unmodifiableList(new ArrayList<>(armorHeaders));
     }
 
     /**
@@ -30,27 +30,27 @@ public class DecryptionResult {
     }
 
     /**
-     * @return {@code true} if the encrypted data was armoured
+     * @return {@code true} if the encrypted data was armored
      */
-    public boolean isArmoured() {
-        return armoured;
+    public boolean isAsciiArmored() {
+        return armored;
     }
 
     /**
-     * @return An <U>unmodifiable</U> {@link List} of extracted armoured
-     * headers - is valid only if {@link #isArmoured()}. <B>Note:</B> might
-     * be empty if the encrypted data was armoured but contained no headers.
+     * @return An <U>unmodifiable</U> {@link List} of extracted armored
+     * headers - is valid only if {@link #isAsciiArmored() armored}. <B>Note:</B>
+     * might be empty if the encrypted data was armored but contained no headers.
      */
-    public List<String> getArmouredHeaders() {
-        return armouredHeaders;
+    public List<String> getArmorHeaders() {
+        return armorHeaders;
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName()
             + "[metadata=" + getFileMetadata()
-            + ", armoured=" + isArmoured()
-            + ", numArmouredHeaders=" + getArmouredHeaders().size()
+            + ", armored=" + isAsciiArmored()
+            + ", numArmorHeaders=" + getArmorHeaders().size()
             + "]";
     }
 

--- a/src/main/java/org/c02e/jpgpj/DecryptionResult.java
+++ b/src/main/java/org/c02e/jpgpj/DecryptionResult.java
@@ -53,6 +53,4 @@ public class DecryptionResult {
             + ", numArmorHeaders=" + getArmorHeaders().size()
             + "]";
     }
-
-
 }

--- a/src/main/java/org/c02e/jpgpj/DecryptionResult.java
+++ b/src/main/java/org/c02e/jpgpj/DecryptionResult.java
@@ -1,0 +1,58 @@
+package org.c02e.jpgpj;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Holds the most detailed information about a decrypted file
+ */
+public class DecryptionResult {
+    private final FileMetadata fileMetadata;
+    private final boolean armoured;
+    private final List<String> armouredHeaders;
+
+    public DecryptionResult(
+            FileMetadata fileMetadata, boolean armoured, Collection<String> armouredHeaders) {
+        this.fileMetadata = fileMetadata;
+        this.armoured = armoured;
+        this.armouredHeaders = ((armouredHeaders == null) || armouredHeaders.isEmpty())
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(armouredHeaders));
+    }
+
+    /**
+     * @return The decrypted {@link FileMetadata} - may be {@code null} if none was provided
+     */
+    public FileMetadata getFileMetadata() {
+        return fileMetadata;
+    }
+
+    /**
+     * @return {@code true} if the encrypted data was armoured
+     */
+    public boolean isArmoured() {
+        return armoured;
+    }
+
+    /**
+     * @return An <U>unmodifiable</U> {@link List} of extracted armoured
+     * headers - is valid only if {@link #isArmoured()}. <B>Note:</B> might
+     * be empty if the encrypted data was armoured but contained no headers.
+     */
+    public List<String> getArmouredHeaders() {
+        return armouredHeaders;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName()
+            + "[metadata=" + getFileMetadata()
+            + ", armoured=" + isArmoured()
+            + ", numArmouredHeaders=" + getArmouredHeaders().size()
+            + "]";
+    }
+
+
+}

--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -302,7 +302,7 @@ public class Decryptor {
      * @param plaintext Decrypted content target {@link OutputStream}
      * @return The {@link DecryptionResult} containing all relevant
      * information that could be extracted from the encrypted data - including
-     * metadata, armoured headers (if any), etc...
+     * metadata, armored headers (if any), etc...
      * @throws IOException if an IO error occurs reading from or writing to
      * the underlying input or output streams.
      * @throws PGPException if the PGP message is not formatted correctly.

--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -553,7 +553,7 @@ public class Decryptor {
 
     /**
      * Wraps stream with ArmoredInputStream if necessary
-     * (to convert ascii-armored content back into binary data).
+     * (to convert ASCII-armored content back into binary data).
      */
     protected InputStream unarmor(InputStream stream)
             throws IOException, PGPException {

--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -295,8 +295,9 @@ public class Decryptor {
 
     /**
      * Decrypts the specified PGP message into the specified output stream,
-     * and (if {@link #isVerificationRequired}) verifies the message
-     * signatures. Does not close or flush the streams.
+     * including the armored headers (if stream was armored and contained
+     * any such headers). If {@link #isVerificationRequired} also verifies
+     * the message signatures. <B>Note:</B> does not close or flush the streams.
      *
      * @param ciphertext PGP message, in binary or ASCII Armor format.
      * @param plaintext Decrypted content target {@link OutputStream}

--- a/src/main/java/org/c02e/jpgpj/EncryptedAsciiArmorHeadersCallback.java
+++ b/src/main/java/org/c02e/jpgpj/EncryptedAsciiArmorHeadersCallback.java
@@ -1,0 +1,21 @@
+package org.c02e.jpgpj;
+
+/**
+ * Used by the encryptor to allow users to configure per-file
+ * armored headers instead/in addition to the global ones that
+ * are set by the encryptor
+ */
+@FunctionalInterface
+public interface EncryptedAsciiArmorHeadersCallback {
+    /**
+     * Invoked by the encryptor <U>after</U> updating the
+     * settings with the configured global headers.
+     *
+     * @param encryptor The {@link Encryptor} that is handling the encryption request
+     * @param meta The input plaintext {@link FileMetadata} - might be empty
+     * (but not {@code null}).
+     * @param manipulator The manipulator that can be used to update the headers
+     */
+    void prepareAsciiArmoredHeaders(
+        Encryptor encryptor, FileMetadata meta, EncryptedAsciiArmorHeadersManipulator manipulator);
+}

--- a/src/main/java/org/c02e/jpgpj/EncryptedAsciiArmorHeadersManipulator.java
+++ b/src/main/java/org/c02e/jpgpj/EncryptedAsciiArmorHeadersManipulator.java
@@ -1,0 +1,54 @@
+package org.c02e.jpgpj;
+
+import java.util.Map;
+
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+
+@FunctionalInterface
+public interface EncryptedAsciiArmorHeadersManipulator {
+    /**
+     * A manipulator that ignores all headers manipulations
+     */
+    EncryptedAsciiArmorHeadersManipulator EMPTY = (name, value) -> { /* do nothing */ };
+
+    /**
+     * Set the specified header value - replace any previous value
+     *
+     * @param name Case <U>sensitive</U> name of header to set. <B>Note:</B> this
+     * method can be used to <U>override</U> the default version header value.
+     * @param value Value to set - if {@code null} then equivalent to header removal
+     */
+    void setHeader(String name, String value);
+
+    /**
+     * Removes specified header - no-op if header not set anyway
+     *
+     * @param name Case <U>sensitive</U> name of header to set. <B>Note:</B> this
+     * method can be used to <U>remove</U> the default version header value.
+     */
+    default void removeHeader(String name) {
+        setHeader(name, null);
+    }
+
+    /**
+     * Replaces existing headers and adds missing ones
+     *
+     * @param headers The headers to update - ignored if {@code null}.
+     * <B>Note:</B> header name is case <U>sensitive</U>
+     */
+    default void updateHeaders(Map<String, String> headers) {
+        if (headers != null) {
+            headers.forEach((name, value) -> setHeader(name, value));
+        }
+    }
+
+    /**
+     * Wraps an {@link ArmoredOutputStream}
+     *
+     * @param aos The stream to wrap - ignored if {@code null}
+     * @return The manipulator wrapping
+     */
+    static EncryptedAsciiArmorHeadersManipulator wrap(ArmoredOutputStream aos) {
+        return (aos == null) ? EMPTY : (name, value) -> aos.setHeader(name, value);
+    }
+}

--- a/src/main/java/org/c02e/jpgpj/Encryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Encryptor.java
@@ -73,6 +73,7 @@ public class Encryptor {
     public static final int MAX_ENCRYPT_COPY_BUFFER_SIZE = 0x10000;
 
     protected boolean asciiArmored;
+    protected boolean removeDefaultArmoredVersionHeader;
     protected int compressionLevel;
 
     protected CompressionAlgorithm compressionAlgorithm;
@@ -295,6 +296,30 @@ public class Encryptor {
     /** Keys to use for encryption and signing. */
     protected void setRing(Ring x) {
         ring = x != null ? x : new Ring();
+    }
+
+    /**
+     * By default the {@link ArmoredOutputStream} adds a &quot;Version&quot;
+     * header - this setting allows users to remove this header (and perhaps
+     * replace it and/or add others - see headers manipulation methods).
+     *
+     * @return {@code true} if &quot;Version&quot; should be removed - default={@code false)
+     */
+    public boolean isRemoveDefaultArmoredVersionHeader() {
+        return removeDefaultArmoredVersionHeader;
+    }
+
+    /**
+     * By default the {@link ArmoredOutputStream} adds a &quot;Version&quot;
+     * header - this setting allows users to remove this header (and perhaps
+     * replace it and/or add others - see headers manipulation methods).
+     *
+     * @param removeDefaultarmoredVersionHeader {@code true} if &quot;Version&quot;
+     * should be removed - default={@code false). <B>Note:</B> relevant only if
+     * {@link #setAsciiArmored(boolean) armored} setting was also set.
+     */
+    public void setRemoveDefaultArmoredVersionHeader(boolean removeDefaultArmoredVersionHeader) {
+        this.removeDefaultArmoredVersionHeader = removeDefaultArmoredVersionHeader;
     }
 
     /**
@@ -592,8 +617,14 @@ public class Encryptor {
      * Wraps with stream that outputs ascii-armored text.
      */
     protected OutputStream armor(OutputStream out) {
-        if (asciiArmored)
-            return new ArmoredOutputStream(out);
+        if (isAsciiArmored()) {
+            ArmoredOutputStream aos = new ArmoredOutputStream(out);
+            if (isRemoveDefaultArmoredVersionHeader()) {
+                aos.setHeader(ArmoredOutputStream.VERSION_HDR, null);
+            }
+            return aos;
+        }
+
         return null;
     }
 

--- a/src/main/java/org/c02e/jpgpj/Ring.java
+++ b/src/main/java/org/c02e/jpgpj/Ring.java
@@ -36,7 +36,7 @@ import org.c02e.jpgpj.util.Util;
  * {@link #load(File)} method, or by loading them from an input stream via the
  * {@link #load(InputStream)} method. A ring can also be constructed from
  * an existing array of keys ({@link #Ring(Key...)}), or from an existing list
- * of keys ({@link #Ring(List)}), or from an ascii-armor text string containing
+ * of keys ({@link #Ring(List)}), or from an ASCII-armor text string containing
  * the keys ({@link #Ring(String)}), or from a file containing the keys
  * ({@link #Ring(File)}), or from an input stream containing the keys
  * ({@link #Ring(InputStream)}).

--- a/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
+++ b/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
@@ -274,17 +274,40 @@ hQEMAyne546XDHBhAQ...
             encryptor.removeDefaultArmoredVersionHeader = true
             encryptor.ring.keys*.passphrase = 'c02e'
             encryptor.encrypt plainIn, cipherOut
-        def decryptor = new Decryptor(new Ring(stream('test-key-1.asc')))
-        decryptor.ring.keys*.passphrase = 'c02e'
-        def result = decryptor.decryptWithFullDetails cipherIn, plainOut
-        def armorHeaders = result.armorHeaders
+            def decryptor = new Decryptor(new Ring(stream('test-key-1.asc')))
+            decryptor.ring.keys*.passphrase = 'c02e'
+            def result = decryptor.decryptWithFullDetails cipherIn, plainOut
+            def armorHeaders = result.armorHeaders
 
         then:
-        result.asciiArmored == true
-        armorHeaders.size() == 0
-        plainOut.toString() == plainText
+            result.asciiArmored == true
+            armorHeaders.size() == 0
+            plainOut.toString() == plainText
     }
 
+    def "encrypt and use user defined ascii armor headers"() {
+        when:
+            def encryptor = new Encryptor(new Ring(stream('test-key-1.asc')))
+            encryptor.asciiArmored = true
+            encryptor.ring.keys*.passphrase = 'c02e'
+            encryptor.updateArmoredHeader("Version", "3.14")
+            encryptor.updateArmoredHeader("Encryptor", "c02e")
+            encryptor.encrypt plainIn, cipherOut
+            
+            def decryptor = new Decryptor(new Ring(stream('test-key-1.asc')))
+            decryptor.ring.keys*.passphrase = 'c02e'
+            def result = decryptor.decryptWithFullDetails cipherIn, plainOut
+            def armorHeaders = result.armorHeaders
+
+        then:
+            result.asciiArmored == true
+            armorHeaders.size() == 2
+            armorHeaders[0].equals("Version: 3.14")
+            armorHeaders[1].equals("Encryptor: c02e")
+
+            plainOut.toString() == plainText
+    }
+    
     def "encrypt and sign file"() {
         when:
         def encryptor = new Encryptor(new Key(file('test-key-1.asc'), 'c02e'))


### PR DESCRIPTION
Note that I am using Java 8 constructs since they greatly simplify the code - I hope it's not a problem. In any case, I recommend declaring (and enforcing in build setup) usage of 1.8 as the minimum version (as of next release) since it is the most widely used version (the older ones are pretty obsolete).