### PR TITLE
Various minor improvements

### DIFF
--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.openpgp.PGPCompressedData;
@@ -293,7 +294,7 @@ public class Decryptor {
      */
     public FileMetadata decrypt(File ciphertext, File plaintext)
             throws IOException, PGPException {
-        if (ciphertext.equals(plaintext))
+        if (Objects.equals(ciphertext.getAbsoluteFile(), plaintext.getAbsoluteFile()))
             throw new IOException("cannot decrypt " + ciphertext +
                 " over itself");
 

--- a/src/main/java/org/c02e/jpgpj/Encryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Encryptor.java
@@ -603,7 +603,7 @@ public class Encryptor {
      */
     public void encrypt(File plaintext, File ciphertext)
             throws IOException, PGPException {
-        if (plaintext.equals(ciphertext))
+        if (Objects.equals(plaintext.getAbsoluteFile(), ciphertext.getAbsoluteFile()))
             throw new IOException("cannot encrypt " + plaintext +
                 " over itself");
 

--- a/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
+++ b/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
@@ -779,7 +779,7 @@ hQEMAyne546XDHBhAQ...
         setup:
         def encryptor = new Encryptor();
         expect:
-        encryptor.estimateOutFileSize(inputSize) == outputSize
+        encryptor.estimateOutFileBufferSize(inputSize) == outputSize
         where:
         inputSize << [
             -1, 0, 1,
@@ -800,7 +800,7 @@ hQEMAyne546XDHBhAQ...
         def encryptor = new Encryptor();
         encryptor.asciiArmored = true
         expect:
-        encryptor.estimateOutFileSize(inputSize) == outputSize
+        encryptor.estimateOutFileBufferSize(inputSize) == outputSize
         where:
         inputSize << [
             -1, 0, 1,
@@ -822,7 +822,7 @@ hQEMAyne546XDHBhAQ...
         def encryptor = new Encryptor(new Ring(stream('test-ring.asc')))
         encryptor.ring.findAll('key-1')*.signing*.forSigning = false
         expect:
-        encryptor.estimateOutFileSize(inputSize) == outputSize
+        encryptor.estimateOutFileBufferSize(inputSize) == outputSize
         where:
         inputSize << [
             -1, 0, 1,
@@ -849,7 +849,7 @@ hQEMAyne546XDHBhAQ...
         when:
         def plainIn = new ByteArrayInputStream(new byte[inputSize])
         encryptor.encrypt plainIn, cipherOut
-        def estimate = encryptor.estimateOutFileSize(inputSize)
+        def estimate = encryptor.estimateOutFileBufferSize(inputSize)
         def actual = cipherOut.size()
         then:
         estimate > actual
@@ -870,7 +870,7 @@ hQEMAyne546XDHBhAQ...
         when:
         def plainIn = new ByteArrayInputStream(new byte[inputSize])
         encryptor.encrypt plainIn, cipherOut
-        def estimate = encryptor.estimateOutFileSize(inputSize)
+        def estimate = encryptor.estimateOutFileBufferSize(inputSize)
         def actual = cipherOut.size()
         then:
         estimate > actual


### PR DESCRIPTION
* Promote methods visibility - for easier use by code that wants to use the same parameters as the encryptor/decryptor
* Expose `wrapSource/targetStream` for code that needs to encrypt streams instead of files - to allow callers to optimize their streams accordingly
* Use `try-with-resource` for clearer code
* Use absolute paths to ensure file not encrypted/decrypted onto itself