### PR TITLE
Added cloning of encryptor/decryptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     compile 'org.bouncycastle:bcpg-jdk15on:1.69'
     compile 'org.slf4j:slf4j-api:1.7.32'
+    testCompile 'junit:junit:4.13.2'
     testCompile 'org.codehaus.groovy:groovy-all:2.5.8'
     testCompile 'org.slf4j:slf4j-simple:1.7.32'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.bouncycastle:bcpg-jdk15on:1.63'
+    compile 'org.bouncycastle:bcpg-jdk15on:1.69'
     compile 'org.slf4j:slf4j-api:1.7.32'
     testCompile 'org.codehaus.groovy:groovy-all:2.5.8'
     testCompile 'org.slf4j:slf4j-simple:1.7.32'

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ repositories {
 
 dependencies {
     compile 'org.bouncycastle:bcpg-jdk15on:1.63'
-    compile 'org.slf4j:slf4j-api:1.7.28'
+    compile 'org.slf4j:slf4j-api:1.7.32'
     testCompile 'org.codehaus.groovy:groovy-all:2.5.8'
-    testCompile 'org.slf4j:slf4j-simple:1.7.28'
+    testCompile 'org.slf4j:slf4j-simple:1.7.32'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 

--- a/mavenCentral.gradle
+++ b/mavenCentral.gradle
@@ -14,10 +14,11 @@ repositories {
 }
 
 dependencies {
-    compile 'org.bouncycastle:bcpg-jdk15on:1.63'
-    compile 'org.slf4j:slf4j-api:1.7.28'
+    compile 'org.bouncycastle:bcpg-jdk15on:1.69'
+    compile 'org.slf4j:slf4j-api:1.7.32'
+    testCompile 'junit:junit:4.13.2'
     testCompile 'org.codehaus.groovy:groovy-all:2.5.8'
-    testCompile 'org.slf4j:slf4j-simple:1.7.28'
+    testCompile 'org.slf4j:slf4j-simple:1.7.32'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 

--- a/src/main/java/org/c02e/jpgpj/Decryptor.java
+++ b/src/main/java/org/c02e/jpgpj/Decryptor.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  * gpg --decrypt --output path/back-to/plaintext.txt path/to/ciphertext.txt.gpg
  * }</pre>
  */
-public class Decryptor {
+public class Decryptor implements Cloneable {
     public static final int DEFAULT_MAX_FILE_BUFFER_SIZE = 0x100000; // 1MB
     public static final boolean DEFAULT_VERIFICATION_REQUIRED = true;
     public static final int DEFAULT_COPY_FILE_BUFFER_SIZE = 0x4000;
@@ -778,6 +778,23 @@ public class Decryptor {
      */
     public byte[] getCopyBuffer() {
         return new byte[getCopyFileBufferSize()];
+    }
+
+    @Override
+    public Decryptor clone() {
+        try {
+            Decryptor other = getClass().cast(super.clone());
+            char[] thisChars = getSymmetricPassphraseChars();
+            // don't call setSymmetricPassphraseChars since it checks if different password provided
+            other.symmetricPassphraseChars = (thisChars == null) ? null : thisChars.clone();
+
+            Ring thisRing = getRing();
+            Ring clonedRing = (thisRing == null) ? null : thisRing.clone();
+            other.setRing(clonedRing);
+            return other;
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException("Unexpected clone failure for " + this);
+        }
     }
 
     /**

--- a/src/main/java/org/c02e/jpgpj/Key.java
+++ b/src/main/java/org/c02e/jpgpj/Key.java
@@ -1,12 +1,14 @@
 package org.c02e.jpgpj;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.bouncycastle.openpgp.PGPException;
 import org.c02e.jpgpj.util.Util;
 
@@ -53,7 +55,7 @@ import org.c02e.jpgpj.util.Util;
  * may ignore this setting, and display an arbitrary user ID,
  * or all user IDs, as the message signer).
  */
-public class Key {
+public class Key implements Cloneable {
     /** Use this value to set the passphrase of a passphrase-less key. */
     public static String NO_PASSPHRASE = "JPGPJ_NO_PASSPHRASE";
 
@@ -184,6 +186,7 @@ public class Key {
      * Display string for the key, including each subkey's usage flags,
      * short ID, and user IDs.
      */
+    @Override
     public String toString() {
         if (Util.isEmpty(subkeys)) return "key empty";
 
@@ -195,6 +198,18 @@ public class Key {
             b.append(subkey.toString());
         }
         return b.toString();
+    }
+
+    @Override
+    public Key clone() {
+        try {
+            Key other = getClass().cast(super.clone());
+            List<Subkey> thisSubkeys = getSubkeys();
+            other.setSubkeys((thisSubkeys == null) ? null : thisSubkeys.stream().map(Subkey::clone).collect(Collectors.toList()));
+            return other;
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException("Unexpected clone failure for " + this);
+        }
     }
 
     /**

--- a/src/main/java/org/c02e/jpgpj/Ring.java
+++ b/src/main/java/org/c02e/jpgpj/Ring.java
@@ -47,7 +47,7 @@ import org.c02e.jpgpj.util.Util;
  * needed to unlock the subkey (which is needed to use the subkey for
  * decryption and signing).
  */
-public class Ring {
+public class Ring implements Cloneable {
     protected List<Key> keys;
 
     /** Constructs a new empty ring. */
@@ -87,6 +87,18 @@ public class Ring {
     public Ring(InputStream stream) throws IOException, PGPException {
         this();
         load(stream);
+    }
+
+    @Override
+    public Ring clone() {
+        try {
+            Ring other = getClass().cast(super.clone());
+            List<Key> thisKeys = getKeys();
+            other.setKeys((thisKeys == null) ? null : new ArrayList<>(thisKeys));
+            return other;
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException("Unexpected clone failure for " + this);
+        }
     }
 
     /**

--- a/src/main/java/org/c02e/jpgpj/Ring.java
+++ b/src/main/java/org/c02e/jpgpj/Ring.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.gpg.keybox.PublicKeyRingBlob;
@@ -94,7 +95,7 @@ public class Ring implements Cloneable {
         try {
             Ring other = getClass().cast(super.clone());
             List<Key> thisKeys = getKeys();
-            other.setKeys((thisKeys == null) ? null : new ArrayList<>(thisKeys));
+            other.setKeys((thisKeys == null) ? null : thisKeys.stream().map(Key::clone).collect(Collectors.toList()));
             return other;
         } catch (CloneNotSupportedException e) {
             throw new UnsupportedOperationException("Unexpected clone failure for " + this);

--- a/src/main/java/org/c02e/jpgpj/Subkey.java
+++ b/src/main/java/org/c02e/jpgpj/Subkey.java
@@ -61,7 +61,7 @@ import org.c02e.jpgpj.util.Util;
  * (however, the private key material will not be zeroed-out; also, the
  * passphrase will not be zeroed-out if it was set via {@link #setPassphrase}).
  */
-public class Subkey {
+public class Subkey implements Cloneable {
     private static final char[] NO_PASSPHRASE = Key.NO_PASSPHRASE.toCharArray();
     private static final char[] EMPTY_PASSPHRASE = new char[0];
 
@@ -116,6 +116,18 @@ public class Subkey {
             b.append(uid);
         }
         return b.toString();
+    }
+
+    @Override
+    public Subkey clone() {
+        try {
+            Subkey other = getClass().cast(super.clone());
+            // Do not use setPassphrasesChars since it checks if different password provided
+            other.passphraseChars = (this.passphraseChars == null) ? null : this.passphraseChars.clone();
+            return other;
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException("Unexpected clone failure for " + this);
+        }
     }
 
     /** True if the subkey should be used for signing messages. */

--- a/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
+++ b/src/test/groovy/org/c02e/jpgpj/EncryptorSpec.groovy
@@ -284,7 +284,7 @@ class EncryptorSpec extends Specification {
             replaceFirst(/(?m)^(hQEMAyne546XDHBhAQ)[\w\+\/\n]+[\w\+\/]={0,2}/, '$1...').
             replaceFirst(/(?m)^=[\w\+\/]+/, '=1234') == '''
 -----BEGIN PGP MESSAGE-----
-Version: BCPG v1.63
+Version: BCPG v1.69
 
 hQEMAyne546XDHBhAQ...
 =1234

--- a/src/test/java/org/c02e/jpgpj/DecryptorTest.java
+++ b/src/test/java/org/c02e/jpgpj/DecryptorTest.java
@@ -1,0 +1,37 @@
+package org.c02e.jpgpj;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class DecryptorTest extends Assert {
+    public DecryptorTest() {
+        super();
+    }
+
+    @Test
+    public void testClone() throws IOException, PGPException {
+        Decryptor original = new Decryptor(loadRing("test-ring.asc"))
+            .withSymmetricPassphraseChars(new char[] { 'h', 'e', 'l', 'l', 'o' })
+            ;
+        Decryptor cloned = original.clone();
+        assertNotSame("Cloned instance reference", original, cloned);
+        assertSame("Cloned logger reference", original.log, cloned.log);
+        assertNotSame("Cloned ring reference", original.getRing(), cloned.getRing());
+        assertNotSame("Cloned passphrase chars reference", original.getSymmetricPassphraseChars(), cloned.getSymmetricPassphraseChars());
+        assertArrayEquals("Clones passphrase chars values", original.getSymmetricPassphraseChars(), cloned.getSymmetricPassphraseChars());
+    }
+
+    protected Ring loadRing(String resourceName) throws IOException, PGPException {
+        ClassLoader cl = getClass().getClassLoader();
+        try (InputStream inputStream = cl.getResourceAsStream(resourceName)) {
+            return new Ring(inputStream);
+        }
+    }
+}

--- a/src/test/java/org/c02e/jpgpj/EncryptorTest.java
+++ b/src/test/java/org/c02e/jpgpj/EncryptorTest.java
@@ -1,0 +1,52 @@
+package org.c02e.jpgpj;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class EncryptorTest extends Assert {
+    public EncryptorTest() {
+        super();
+    }
+
+    @Test
+    public void testClone() throws IOException, PGPException {
+        Encryptor original = new Encryptor(loadRing("test-ring.asc"))
+            .withSymmetricPassphraseChars(new char[] { 'h', 'e', 'l', 'l', 'o' })
+            .withArmoredHeader("hello", "world")
+            ;
+        Encryptor cloned = original.clone();
+        assertNotSame("Cloned instance reference", original, cloned);
+        assertSame("Cloned logger reference", original.log, cloned.log);
+        assertNotSame("Cloned ring reference", original.getRing(), cloned.getRing());
+        assertNotSame("Cloned passphrase chars reference", original.getSymmetricPassphraseChars(), cloned.getSymmetricPassphraseChars());
+        assertArrayEquals("Clones passphrase chars values", original.getSymmetricPassphraseChars(), cloned.getSymmetricPassphraseChars());
+
+        Map<String, String> orgHdrs = original.getArmoredHeaders();
+        Map<String, String> clnHdrs = cloned.getArmoredHeaders();
+        assertNotSame("Cloned armored headers map reference", orgHdrs, clnHdrs);
+        assertEquals("Cloned armored headers map size", orgHdrs.size(), clnHdrs.size());
+        for (Map.Entry<String, String> e : orgHdrs.entrySet()) {
+            String name = e.getKey();
+            String orgValue = e.getValue();
+            String clnValue = clnHdrs.get(name);
+            assertSame("Mismatched cloned header value for key=" + name, orgValue, clnValue);
+        }
+
+    }
+
+    protected Ring loadRing(String resourceName) throws IOException, PGPException {
+        ClassLoader cl = getClass().getClassLoader();
+        try (InputStream inputStream = cl.getResourceAsStream(resourceName)) {
+            return new Ring(inputStream);
+        }
+    }
+
+}

--- a/src/test/java/org/c02e/jpgpj/RingTest.java
+++ b/src/test/java/org/c02e/jpgpj/RingTest.java
@@ -25,8 +25,19 @@ public class RingTest extends Assert {
         assertNotSame("Cloned instance reference", original, cloned);
         assertNotSame("Cloned keys list reference", orgKeys, clnKeys);
         assertEquals("Cloned keys count", orgKeys.size(), clnKeys.size());
-        for (int index = 0; index < orgKeys.size(); index++) {
-            assertSame("Mismatched ring key reference at index #" + index, orgKeys.get(index), clnKeys.get(index));
+
+        for (int keyIndex = 0; keyIndex < orgKeys.size(); keyIndex++) {
+            Key oKey = orgKeys.get(keyIndex);
+            Key cKey = clnKeys.get(keyIndex);
+            assertNotSame("Uncloned ring key reference at index #" + keyIndex, oKey, cKey);
+            List<Subkey> orgSubs = oKey.getSubkeys();
+            List<Subkey> clnSubs = cKey.getSubkeys();
+            assertNotSame("Cloned sub-keys list reference for key #" + keyIndex, orgSubs, clnSubs);
+            assertEquals("Cloned sub-keys count for key #" + keyIndex, orgSubs.size(), clnSubs.size());
+
+            for (int subIndex = 0; subIndex < orgSubs.size(); subIndex++) {
+                assertNotSame("Clone sub-key #" + subIndex + " reference of key #" + keyIndex, orgSubs.get(subIndex), clnSubs.get(subIndex));
+            }
         }
     }
 

--- a/src/test/java/org/c02e/jpgpj/RingTest.java
+++ b/src/test/java/org/c02e/jpgpj/RingTest.java
@@ -1,0 +1,39 @@
+package org.c02e.jpgpj;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class RingTest extends Assert {
+    public RingTest() {
+        super();
+    }
+
+    @Test
+    public void testClone() throws IOException, PGPException {
+        Ring original = loadRing("test-ring.asc");
+        List<Key> orgKeys = original.getKeys();
+        Ring cloned = original.clone();
+        List<Key> clnKeys = cloned.getKeys();
+        assertNotSame("Cloned instance reference", original, cloned);
+        assertNotSame("Cloned keys list reference", orgKeys, clnKeys);
+        assertEquals("Cloned keys count", orgKeys.size(), clnKeys.size());
+        for (int index = 0; index < orgKeys.size(); index++) {
+            assertSame("Mismatched ring key reference at index #" + index, orgKeys.get(index), clnKeys.get(index));
+        }
+    }
+
+    protected Ring loadRing(String resourceName) throws IOException, PGPException {
+        ClassLoader cl = getClass().getClassLoader();
+        try (InputStream inputStream = cl.getResourceAsStream(resourceName)) {
+            return new Ring(inputStream);
+        }
+    }
+}


### PR DESCRIPTION
The expected use-case is as follows:

* User sets up a "template" encryptor/decryptor - cipher, compression, keys, etc.
* There are several **threads** that according to some input and/or business logic  apply the template with some minor changes - e.g., different symmetric password, different compression, with/out armored headers, etc.
* Since an encryptor/decryptor is stateful, the threads cannot share the same instance so they need to create a new one to be used locally by each thread.
* By providing *clone()* method implementation we simplify the code since threads do not need to re-initialize the encryptor/decryptor from scratch (which could be time consuming) - only modify the specific settings they need locally
* Furthermore, by using the  *clone()* method  we ensure that users don't have to copy each setting individually from the template to the local copy - thus avoiding possible errors by forgetting to copy a field, failing to create a new copy for shared compound objects references (e.g., *Ring*, armored headers, etc.) or not keeping up with future changes by not copying new fields we might add.